### PR TITLE
fix: locking h5py version to 3.2.1 

### DIFF
--- a/pytorch/jobs/docker/1.8/py3/Dockerfile.cpu
+++ b/pytorch/jobs/docker/1.8/py3/Dockerfile.cpu
@@ -116,6 +116,7 @@ RUN ${PIP} install --no-cache --upgrade \
         decorator==4.4.0 \
         dask==2.30.0 \
         dwave-ocean-sdk==3.3.0 \
+        h5py==3.2.1 \
         ipykernel==5.3.4 \
         jinja2==2.11.3 \
         keras==2.4.3 \

--- a/tensorflow/jobs/docker/2.4/py3/Dockerfile.cpu
+++ b/tensorflow/jobs/docker/2.4/py3/Dockerfile.cpu
@@ -19,6 +19,7 @@ RUN ${PIP} install --no-cache --upgrade \
         decorator==4.4.0 \
         dask==2.30.0 \
         dwave-ocean-sdk==3.3.0 \
+        h5py==3.2.1 \
         ipykernel==5.3.4 \
         jinja2==2.11.3 \
         keras==2.4.3 \


### PR DESCRIPTION
 locking h5py version to 3.2.1 because of https://github.com/PennyLaneAI/pennylane/issues/1429

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
