### PR TITLE
change: Update Amazon Braket PennyLane Plugin to 1.5.6

### DIFF
--- a/pytorch/jobs/docker/1.8/py3/Dockerfile.cpu
+++ b/pytorch/jobs/docker/1.8/py3/Dockerfile.cpu
@@ -110,7 +110,7 @@ RUN ${PIP} install --no-cache --upgrade \
         amazon-braket-ocean-plugin==1.0.6 \
         amazon-braket-schemas==1.8.0 \
         amazon-braket-sdk==1.18.0 \
-        amazon-braket-pennylane-plugin==1.5.2 \
+        amazon-braket-pennylane-plugin==1.5.6 \
         awscli==1.22.15 \
         botocore==1.23.15 \
         boto3==1.20.15 \

--- a/tensorflow/jobs/docker/2.4/py3/Dockerfile.cpu
+++ b/tensorflow/jobs/docker/2.4/py3/Dockerfile.cpu
@@ -13,7 +13,7 @@ RUN ${PIP} install --no-cache --upgrade \
         amazon-braket-ocean-plugin==1.0.6 \
         amazon-braket-schemas==1.8.0 \
         amazon-braket-sdk==1.18.0 \
-        amazon-braket-pennylane-plugin==1.5.2 \
+        amazon-braket-pennylane-plugin==1.5.6 \
         awscli==1.22.15 \
         botocore==1.23.15 \
         boto3==1.20.15 \


### PR DESCRIPTION
This change is to match the version of the  Amazon Braket PennyLane Plugin for the containers the the version in the Braket NBIs

*Issue #, if available:* None

*Description of changes:* Update the version of the Amazon Braket PennyLane Plugin to 1.5.6. This matches the current version of the Amazon Braket PennyLane Plugin  in the Braket Notebook Instances.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
