### PR TITLE
fix: pin pennylane dependency in base image

### DIFF
--- a/base/jobs/docker/1.0/py3/Dockerfile.cpu
+++ b/base/jobs/docker/1.0/py3/Dockerfile.cpu
@@ -121,6 +121,7 @@ RUN ${PIP} install --no-cache --upgrade \
         matplotlib==3.2.2 \
         numpy==1.21.4 \
         pandas==1.1.4 \
+        pennylane==0.22.0 \
         rsa==4.4.1 \
         scikit-learn==0.20.3 \
         requests==2.26.0 \


### PR DESCRIPTION
*Issue #, if available:*
#41 

*Description of changes:*
Fixes issue for running Pennylane jobs with base containers. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
