### PR TITLE
fix: adding QAOA test for base container.

### DIFF
--- a/test/braket_tests/base/test_jobs_qaoa.py
+++ b/test/braket_tests/base/test_jobs_qaoa.py
@@ -14,7 +14,7 @@
 from ..common.braket_jobs_util import job_test
 
 
-def test_qaoa_circuit(account, region, role, s3_bucket, image_list):
+def test_qaoa_circuit(account, role, s3_bucket, image_list):
     assert len(image_list) > 0, "Unable to find images for testing"
     create_job_args = {
         "source_module": "./test/resources/",

--- a/test/braket_tests/base/test_jobs_qaoa.py
+++ b/test/braket_tests/base/test_jobs_qaoa.py
@@ -14,10 +14,20 @@
 from ..common.braket_jobs_util import job_test
 
 
-def test_bell_circuit(account, region, role, s3_bucket, s3_location, image_list):
+def test_qaoa_circuit(account, region, role, s3_bucket, image_list):
     assert len(image_list) > 0, "Unable to find images for testing"
     create_job_args = {
-        "source_module": "./test/resources/bell_circuit.py",
+        "source_module": "./test/resources/",
+        "entry_point": "resources.qaoa_entry_point",
+        "hyperparameters": {
+            "p": "2",
+            "seed": "1967",
+            "max_parallel": "10",
+            "num_iterations": "5",
+            "stepsize": "0.1",
+            "shots": "100",
+            "interface": "autograd",
+        }
     }
     for image_path in image_list:
-        job_test(account, role, s3_bucket, image_path, "bell", **create_job_args)
+        job_test(account, role, s3_bucket, image_path, "base-qaoa", **create_job_args)

--- a/test/braket_tests/pytorch/test_jobs_qaoa.py
+++ b/test/braket_tests/pytorch/test_jobs_qaoa.py
@@ -14,7 +14,7 @@
 from ..common.braket_jobs_util import job_test
 
 
-def test_qaoa_circuit(account, region, role, s3_bucket, image_list):
+def test_qaoa_circuit(account, role, s3_bucket, image_list):
     assert len(image_list) > 0, "Unable to find images for testing"
     create_job_args = {
         "source_module": "./test/resources/",

--- a/test/braket_tests/tensorflow/test_jobs_qaoa.py
+++ b/test/braket_tests/tensorflow/test_jobs_qaoa.py
@@ -14,7 +14,7 @@
 from ..common.braket_jobs_util import job_test
 
 
-def test_qaoa_circuit(account, region, role, s3_bucket, image_list):
+def test_qaoa_circuit(account, role, s3_bucket, image_list):
     assert len(image_list) > 0, "Unable to find images for testing"
     create_job_args = {
         "source_module": "./test/resources/",

--- a/test/resources/qaoa_entry_point.py
+++ b/test/resources/qaoa_entry_point.py
@@ -16,7 +16,7 @@ import os
 import time
 
 import networkx as nx
-import numpy as np
+from pennylane import numpy as np
 import pennylane as qml
 
 from braket.jobs import save_job_checkpoint, save_job_result


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I also had to change the way we import numpy because I was getting conversion errors with:
  "Attempted to differentiate a function with no trainable parameters. "
It seems like pytorch and tensorflow do this conversion for us, but not when it's done without them. 

I tested it through local jobs with both base and pytorch containers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
