### PR TITLE
fix: unpin python rsa version

### DIFF
--- a/base/jobs/docker/1.0/py3/Dockerfile.cpu
+++ b/base/jobs/docker/1.0/py3/Dockerfile.cpu
@@ -121,7 +121,6 @@ RUN ${PIP} install --no-cache --upgrade \
         pandas==1.1.4 \
         pennylane==0.27.0 \
         PennyLane-Lightning==0.27.0 \
-        rsa==4.4.1 \
         scikit-learn==0.20.3 \
         requests==2.26.0 \
         scipy==1.7.3

--- a/pytorch/jobs/docker/1.9/py3/Dockerfile.gpu
+++ b/pytorch/jobs/docker/1.9/py3/Dockerfile.gpu
@@ -98,7 +98,6 @@ RUN ${PIP} install --no-cache --upgrade \
         protobuf==3.12.4 \
         pydantic==1.9.0 \
         requests==2.26.0 \
-        rsa==4.4.1 \
         scikit-learn==0.20.3 \
         six==1.15.0 \
         scipy==1.7.3 \

--- a/tensorflow/jobs/docker/2.4/py3/Dockerfile.gpu
+++ b/tensorflow/jobs/docker/2.4/py3/Dockerfile.gpu
@@ -35,7 +35,6 @@ RUN ${PIP} install --no-cache --upgrade \
         protobuf==3.12.4 \
         pydantic==1.9.0 \
         requests==2.26.0 \
-        rsa==4.4.1 \
         scikit-learn==0.20.3 \
         six==1.15.0 \
         scipy==1.7.3 \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removes the explicit pinning of the version of the rsa pip package. This package is still installed as a dependency of awscli.

*Testing done:*
Unit tests, and running jobs notebook examples with BYOC

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-containers/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
