### PR TITLE
fix: bump sagemaker-training to 4.4.10 in TF and base images

### DIFF
--- a/base/jobs/docker/1.0/py3/Dockerfile.cpu
+++ b/base/jobs/docker/1.0/py3/Dockerfile.cpu
@@ -123,7 +123,7 @@ RUN ${PIP} install --no-cache --upgrade \
         requests==2.26.0 \
         scipy==1.9.3
 
-RUN ${PIP} install --no-cache --upgrade sagemaker-training==4.1.3
+RUN ${PIP} install --no-cache --upgrade sagemaker-training==4.4.10
 
 RUN HOME_DIR=/root \
  && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \

--- a/tensorflow/jobs/docker/2.12/py3/Dockerfile.gpu
+++ b/tensorflow/jobs/docker/2.12/py3/Dockerfile.gpu
@@ -37,7 +37,7 @@ RUN ${PIP} install --no-cache --upgrade \
         scipy==1.9.3 \
         typing_extensions==4.3.0
 
-RUN ${PIP} install --no-cache --upgrade sagemaker-training==4.1.3
+RUN ${PIP} install --no-cache --upgrade sagemaker-training==4.4.10
 
 # install cuQuantum
 RUN wget https://developer.download.nvidia.com/compute/cuquantum/redist/cuquantum/linux-x86_64/cuquantum-linux-x86_64-22.03.0.40-archive.tar.xz && tar xvf ./cuquantum-linux-x86_64-22.03.0.40-archive.tar.xz


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Older versions use `collections.mapping`. This version of sagemaker-training uses collections.abc.mapping (the correct way to import)

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-containers/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
