### PR TITLE
infra: increase baseline size for cuda image

### DIFF
--- a/cudaq/buildspec.yml
+++ b/cudaq/buildspec.yml
@@ -27,7 +27,7 @@ images:
   BuildCudaqCPUJobsPy3DockerImage:
     <<: *JOBS_REPOSITORY
     build: &CUDAQ_CPU_JOBS_PY3 false
-    image_size_baseline: 5500
+    image_size_baseline: 7000
     device_type: &DEVICE_TYPE cpu
     python_version: &DOCKER_PYTHON_VERSION py3
     tag_python_version: &TAG_PYTHON_VERSION py312


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- This resolves the build failure for the cuda images, since the updating the ubuntu version has increased the image size. 

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-containers/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
