### PR TITLE
fix: add mpi4py to base container

### DIFF
--- a/base/jobs/docker/1.0/py3/requirements.txt
+++ b/base/jobs/docker/1.0/py3/requirements.txt
@@ -7,6 +7,7 @@ botocore==1.42.97
 boto3==1.42.97
 dask==2024.8.0
 matplotlib==3.10.9
+mpi4py
 numpy==2.2.6
 pandas==2.3.3
 pennylane==0.44.1

--- a/cudaq/jobs/docker/0.14/py3/requirements.txt
+++ b/cudaq/jobs/docker/0.14/py3/requirements.txt
@@ -1,7 +1,3 @@
-# CUDA-Q quantum computing framework packages
 cudaq==0.14.0
 cudaq-qec==0.6.0
 cudaq-solvers==0.6.0
-
-# MPI support as recommended by CUDA-Q
-mpi4py

--- a/cudaq/jobs/docker/0.14/py3/requirements.txt
+++ b/cudaq/jobs/docker/0.14/py3/requirements.txt
@@ -1,3 +1,7 @@
+# CUDA-Q quantum computing framework packages
 cudaq==0.14.0
 cudaq-qec==0.6.0
 cudaq-solvers==0.6.0
+
+# MPI support as recommended by CUDA-Q
+mpi4py

--- a/test/braket_tests/base/test_mpi.py
+++ b/test/braket_tests/base/test_mpi.py
@@ -21,6 +21,10 @@ and MCA parameter configuration in base/jobs/docker/1.0/py3/Dockerfile.cpu.
 import re
 
 from ..common.image_run_util import run_in_image
+from ..common.mpi_checks import (
+    assert_mpi4py_init_no_crash,
+    assert_mpi_runtime_launches_cleanly,
+)
 
 
 # Strictly pin to OpenMPI 4.1.x.
@@ -94,3 +98,19 @@ def test_mpi_mca_params_applied(image_list):
                 f'Expected MCA param {param}={value} loaded from config file '
                 f"in {image_path}, but did not find it in ompi_info output."
             )
+
+
+def test_mpi_runtime_launches_cleanly(image_list):
+    """Launching a trivial rank in the image's default env must succeed cleanly.
+    Guards against MCA flags inconsistent with how OpenMPI was built in the
+    base Dockerfile (e.g. enabling a transport that wasn't compiled in).
+    """
+    assert_mpi_runtime_launches_cleanly(image_list)
+
+
+def test_mpi4py_init_no_crash_default_env(image_list):
+    """mpi4py must import and complete MPI_Init cleanly against the base image's
+    from-source OpenMPI build. Exercises actual libmpi load + init, which is a
+    stronger check than the mpirun-only tests above.
+    """
+    assert_mpi4py_init_no_crash(image_list)

--- a/test/braket_tests/common/mpi_checks.py
+++ b/test/braket_tests/common/mpi_checks.py
@@ -1,0 +1,132 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+"""Shared MPI smoke-test helpers used by multiple image profiles.
+
+Each helper runs a trivial check inside every image in ``image_list`` and
+raises AssertionError on failure, so callers in profile-specific test modules
+can stay a one-liner while keeping their own test names and docstrings to
+document intent.
+"""
+
+from .image_run_util import run_in_image
+
+
+def assert_mpi_runtime_launches_cleanly(image_list):
+    """Assert ``mpirun -n 1 /bin/true`` succeeds cleanly in each image.
+
+    Catches Dockerfile changes that set MCA flags inconsistent with how the
+    underlying OpenMPI was built (e.g. enabling a transport or CUDA support
+    that wasn't compiled in), which typically surface as a segfault during
+    library init or a ``was not compiled with`` error string.
+
+    Uses /bin/true so this helper has no Python-level MPI dependency and can
+    run against images that don't ship mpi4py.
+    """
+    assert len(image_list) > 0, "Unable to find images for testing"
+    for image_path in image_list:
+        result = run_in_image(
+            image_path,
+            ["bash", "-lc", "mpirun -n 1 --allow-run-as-root /bin/true"],
+        )
+        assert result.returncode == 0, (
+            f"mpirun failed in {image_path} (exit {result.returncode}).\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        combined_lower = result.combined.lower()
+        for bad in ("segmentation fault", "was not compiled with"):
+            assert bad not in combined_lower, (
+                f"mpirun emitted unexpected error {bad!r} in {image_path}:\n"
+                f"{result.combined}"
+            )
+
+
+def assert_mpi4py_init_no_crash(image_list):
+    """Assert mpi4py can import and complete ``MPI_Init`` cleanly in each image.
+
+    This is a stronger check than ``assert_mpi_runtime_launches_cleanly`` because
+    it actually loads libmpi into a Python process and calls into it. Originally
+    added to catch an OMPI_MCA_opal_cuda_support misconfiguration that caused
+    MPI_Init to emit ``opal_cuda_support`` errors and segfault on non-GPU hosts.
+
+    Requires mpi4py to be installed in the image.
+    """
+    assert len(image_list) > 0, "Unable to find images for testing"
+    for image_path in image_list:
+        result = run_in_image(
+            image_path,
+            [
+                "python",
+                "-c",
+                "from mpi4py import MPI; print(MPI.Get_library_version().strip())",
+            ],
+        )
+        assert result.returncode == 0, (
+            f"mpi4py MPI_Init crashed in {image_path} (exit {result.returncode}).\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        combined_lower = result.combined.lower()
+        for bad in ("segmentation fault", "opal_cuda_support", "mpi_cuda_support"):
+            assert bad not in combined_lower, (
+                f"Unexpected MPI error string {bad!r} in {image_path} output:\n"
+                f"{result.combined}"
+            )
+
+
+# CUDA-Q's activate_custom_mpi.sh compiles this shared object against whatever
+# MPI headers are present in the image at build time (base's from-source OpenMPI
+# in the cudaq image, the DLC's OpenMPI under /opt/amazon/openmpi in the pytorch
+# image). Both images install cudaq from pip into the same site-packages layout,
+# so the plugin ends up at this path either way. Absence of the file means
+# activate_custom_mpi.sh did not run or failed silently during image build, in
+# which case ``cudaq.mpi`` APIs raise ``RuntimeError: No MPI support can be found``.
+CUDAQ_MPI_PLUGIN_PATH = (
+    "/usr/local/lib/python3.12/site-packages/distributed_interfaces/"
+    "libcudaq_distributed_interface_mpi.so"
+)
+
+
+def assert_cudaq_mpi_plugin_present(image_list):
+    """Assert CUDA-Q's custom MPI plugin ``.so`` exists in each image."""
+    assert len(image_list) > 0, "Unable to find images for testing"
+    for image_path in image_list:
+        result = run_in_image(image_path, ["test", "-f", CUDAQ_MPI_PLUGIN_PATH])
+        assert result.returncode == 0, (
+            f"CUDA-Q MPI plugin missing at {CUDAQ_MPI_PLUGIN_PATH} in {image_path}. "
+            f"activate_custom_mpi.sh likely did not run or failed silently during "
+            f"image build."
+        )
+
+
+def assert_cudaq_mpi_initialize_finalize(image_list):
+    """Assert ``cudaq.mpi.initialize()`` / ``finalize()`` succeed in each image.
+
+    End-to-end check that CUDA-Q's MPI subsystem links against the image's
+    OpenMPI correctly. Stronger than the plugin-presence check because it
+    actually loads and exercises the plugin.
+    """
+    assert len(image_list) > 0, "Unable to find images for testing"
+    script = (
+        "import cudaq; "
+        "cudaq.mpi.initialize(); "
+        "assert cudaq.mpi.rank() == 0; "
+        "assert cudaq.mpi.num_ranks() == 1; "
+        "cudaq.mpi.finalize()"
+    )
+    for image_path in image_list:
+        result = run_in_image(image_path, ["python", "-c", script])
+        assert result.returncode == 0, (
+            f"cudaq.mpi initialize/finalize failed in {image_path} "
+            f"(exit {result.returncode}).\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )

--- a/test/braket_tests/cudaq/test_mpi.py
+++ b/test/braket_tests/cudaq/test_mpi.py
@@ -18,16 +18,10 @@ complete in a few seconds per image. They guard against regressions in how the
 CUDA-Q image composes on top of the base image's OpenMPI build.
 """
 
-from ..common.image_run_util import run_in_image
-
-
-# CUDA-Q's activate_custom_mpi.sh compiles this shared object against the
-# base image's MPI headers at image-build time. Its absence means the plugin
-# failed to build (silently, since the RUN step would have errored loudly) or
-# was installed to an unexpected path.
-CUDAQ_MPI_PLUGIN_PATH = (
-    "/usr/local/lib/python3.12/site-packages/distributed_interfaces/"
-    "libcudaq_distributed_interface_mpi.so"
+from ..common.mpi_checks import (
+    assert_cudaq_mpi_initialize_finalize,
+    assert_cudaq_mpi_plugin_present,
+    assert_mpi4py_init_no_crash,
 )
 
 
@@ -35,43 +29,19 @@ def test_mpi_init_no_crash_default_env(image_list):
     """Regression test: when OMPI_MCA_opal_cuda_support=true was set in the
     CUDA-Q Dockerfile but the base OpenMPI was not built with --with-cuda,
     MPI_Init would emit `opal_cuda_support` errors and segfault during
-    library initialization on non-GPU hosts. This runs a trivial MPI library
-    probe in the image's default env and asserts clean success.
+    library initialization on non-GPU hosts. Verifies CUDA-Q's image build
+    didn't reintroduce that (or a similar) misconfiguration on top of base.
     """
-    assert len(image_list) > 0, "Unable to find images for testing"
-    for image_path in image_list:
-        result = run_in_image(
-            image_path,
-            [
-                "python",
-                "-c",
-                "from mpi4py import MPI; print(MPI.Get_library_version().strip())",
-            ],
-        )
-        assert result.returncode == 0, (
-            f"mpi4py MPI_Init crashed in {image_path} (exit {result.returncode}).\n"
-            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-        )
-        combined_lower = result.combined.lower()
-        for bad in ("segmentation fault", "opal_cuda_support", "mpi_cuda_support"):
-            assert bad not in combined_lower, (
-                f"Unexpected MPI error string {bad!r} in {image_path} output:\n"
-                f"{result.combined}"
-            )
+    assert_mpi4py_init_no_crash(image_list)
 
 
 def test_cudaq_mpi_plugin_present(image_list):
     """CUDA-Q's custom MPI plugin is compiled by activate_custom_mpi.sh during
-    image build. If the plugin is missing, CUDA-Q's distributed MPI interface
-    will fall back to a stub and silently run as a single rank.
+    image build against the base image's from-source OpenMPI. If the plugin is
+    missing, CUDA-Q's distributed MPI interface will fall back to a stub and
+    silently run as a single rank.
     """
-    assert len(image_list) > 0, "Unable to find images for testing"
-    for image_path in image_list:
-        result = run_in_image(image_path, ["test", "-f", CUDAQ_MPI_PLUGIN_PATH])
-        assert result.returncode == 0, (
-            f"CUDA-Q MPI plugin missing at {CUDAQ_MPI_PLUGIN_PATH} in {image_path}. "
-            f"activate_custom_mpi.sh likely failed silently during image build."
-        )
+    assert_cudaq_mpi_plugin_present(image_list)
 
 
 def test_cudaq_mpi_initialize_finalize(image_list):
@@ -79,18 +49,4 @@ def test_cudaq_mpi_initialize_finalize(image_list):
     base image's OpenMPI. Covers linkage of libcudaq_distributed_interface_mpi.so
     in addition to basic MPI runtime sanity.
     """
-    assert len(image_list) > 0, "Unable to find images for testing"
-    script = (
-        "import cudaq; "
-        "cudaq.mpi.initialize(); "
-        "assert cudaq.mpi.rank() == 0; "
-        "assert cudaq.mpi.num_ranks() == 1; "
-        "cudaq.mpi.finalize()"
-    )
-    for image_path in image_list:
-        result = run_in_image(image_path, ["python", "-c", script])
-        assert result.returncode == 0, (
-            f"cudaq.mpi initialize/finalize failed in {image_path} "
-            f"(exit {result.returncode}).\n"
-            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-        )
+    assert_cudaq_mpi_initialize_finalize(image_list)

--- a/test/braket_tests/pytorch/test_mpi.py
+++ b/test/braket_tests/pytorch/test_mpi.py
@@ -25,16 +25,10 @@ libfabric/EFA + NCCL for high-bandwidth GPU collectives, not CUDA-aware MPI.
 """
 
 from ..common.image_run_util import run_in_image
-
-
-# CUDA-Q's activate_custom_mpi.sh compiles this shared object against the
-# MPI headers at image-build time. In the PyTorch image the compiler uses
-# the DLC's OpenMPI under /opt/amazon/openmpi. Absence of this file means
-# activate_custom_mpi.sh was not run (or failed silently), in which case
-# cudaq.mpi APIs raise `RuntimeError: No MPI support can be found`.
-CUDAQ_MPI_PLUGIN_PATH = (
-    "/usr/local/lib/python3.12/site-packages/distributed_interfaces/"
-    "libcudaq_distributed_interface_mpi.so"
+from ..common.mpi_checks import (
+    assert_cudaq_mpi_initialize_finalize,
+    assert_cudaq_mpi_plugin_present,
+    assert_mpi_runtime_launches_cleanly,
 )
 
 
@@ -49,63 +43,29 @@ def test_mpirun_available(image_list):
 
 
 def test_mpi_runtime_launches_cleanly(image_list):
-    """Regression test mirroring the cudaq image check: `mpirun` must be able
-    to launch a trivial process in the image's default environment without
-    emitting errors or crashing. This catches any Dockerfile change that sets
-    an MCA flag inconsistent with how the underlying OpenMPI was built.
+    """Regression test mirroring the base/cudaq image checks: `mpirun` must be
+    able to launch a trivial process in the image's default environment without
+    emitting errors or crashing. Catches any Dockerfile change that sets an MCA
+    flag inconsistent with how the underlying OpenMPI was built.
 
     Uses /bin/true so we don't depend on mpi4py being installed in the DLC.
     """
-    assert len(image_list) > 0, "Unable to find images for testing"
-    for image_path in image_list:
-        result = run_in_image(
-            image_path,
-            ["bash", "-lc", "mpirun -n 1 --allow-run-as-root /bin/true"],
-        )
-        assert result.returncode == 0, (
-            f"mpirun failed in {image_path} (exit {result.returncode}).\n"
-            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-        )
-        combined_lower = result.combined.lower()
-        for bad in ("segmentation fault", "was not compiled with"):
-            assert bad not in combined_lower, (
-                f"mpirun emitted unexpected error {bad!r} in {image_path}:\n"
-                f"{result.combined}"
-            )
+    assert_mpi_runtime_launches_cleanly(image_list)
 
 
 def test_cudaq_mpi_plugin_present(image_list):
     """The pytorch image installs cudaq from pip but must also run
     activate_custom_mpi.sh during image build to compile the MPI plugin
-    against the DLC's OpenMPI. Without this, cudaq.mpi APIs are unusable.
+    against the DLC's OpenMPI under /opt/amazon/openmpi. Without this,
+    cudaq.mpi APIs raise ``RuntimeError: No MPI support can be found``.
     """
-    assert len(image_list) > 0, "Unable to find images for testing"
-    for image_path in image_list:
-        result = run_in_image(image_path, ["test", "-f", CUDAQ_MPI_PLUGIN_PATH])
-        assert result.returncode == 0, (
-            f"CUDA-Q MPI plugin missing at {CUDAQ_MPI_PLUGIN_PATH} in {image_path}. "
-            f"activate_custom_mpi.sh likely did not run during image build."
-        )
+    assert_cudaq_mpi_plugin_present(image_list)
 
 
 def test_cudaq_mpi_initialize_finalize(image_list):
     """End-to-end check that CUDA-Q's MPI subsystem initializes and finalizes
     cleanly in the pytorch image. Specifically guards against regressions where
-    the cudaq pip install is present but its custom MPI plugin isn't wired up,
-    causing cudaq.mpi.* to raise `RuntimeError: No MPI support can be found`.
+    the cudaq pip install is present but its custom MPI plugin isn't wired up
+    against the DLC's OpenMPI.
     """
-    assert len(image_list) > 0, "Unable to find images for testing"
-    script = (
-        "import cudaq; "
-        "cudaq.mpi.initialize(); "
-        "assert cudaq.mpi.rank() == 0; "
-        "assert cudaq.mpi.num_ranks() == 1; "
-        "cudaq.mpi.finalize()"
-    )
-    for image_path in image_list:
-        result = run_in_image(image_path, ["python", "-c", script])
-        assert result.returncode == 0, (
-            f"cudaq.mpi initialize/finalize failed in {image_path} "
-            f"(exit {result.returncode}).\n"
-            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-        )
+    assert_cudaq_mpi_initialize_finalize(image_list)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added mpi4py to base container's requirements.
The SageMaker training toolkit launches MPI jobs as `python -m mpi4py braket_container.py`, which requires mpi4py to be installed in the image. Without it, MPI jobs fail before `braket_container.py` even starts. The base container already builds OpenMPI from source but was missing the Python bindings.

*Testing done:*
Tested MPI jobs on a container with the chage.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-containers/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
