### PR TITLE
feat: Enable MPI for hybrid jobs

### DIFF
--- a/cudaq/jobs/docker/0.14/py3/Dockerfile.cpu
+++ b/cudaq/jobs/docker/0.14/py3/Dockerfile.cpu
@@ -26,6 +26,40 @@ COPY requirements.txt /
 RUN ${PIP} install --no-cache --upgrade \
         -r requirements.txt
 
+# Rebuild OpenMPI with CUDA-aware support.
+# cuStateVec's distributed index bit swap API passes GPU device pointers to
+# MPI_Isend/MPI_Irecv, which requires CUDA-aware MPI (--with-cuda).
+# See: https://docs.nvidia.com/cuda/cuquantum/latest/custatevec/overview/distributed-index-bit-swap.html
+ENV CUDA_HOME=${CUDAQ_PATH}/nvidia/cuda_runtime
+ENV OPENMPI_VERSION=4.1.8
+ENV OPENMPI_SERIES=v4.1
+RUN mkdir -p ${CUDA_HOME}/lib64/stubs \
+    && echo 'void cuInit() {}' | gcc -shared -o ${CUDA_HOME}/lib64/stubs/libcuda.so -x c - \
+    && cd /tmp \
+    && curl -fSsL -O https://download.open-mpi.org/release/open-mpi/${OPENMPI_SERIES}/openmpi-${OPENMPI_VERSION}.tar.gz \
+    && tar xzf openmpi-${OPENMPI_VERSION}.tar.gz \
+    && cd openmpi-${OPENMPI_VERSION} \
+    && ./configure \
+        --with-cuda=${CUDA_HOME} \
+        --enable-orterun-prefix-by-default \
+        --disable-debug \
+        --enable-shared \
+        --disable-mpi-fortran \
+        --disable-oshmem \
+        --prefix=/usr/local \
+    && make -j $(nproc) all \
+    && make install \
+    && ldconfig \
+    && rm -rf /tmp/openmpi-* \
+    && mv /usr/local/bin/mpirun /usr/local/bin/mpirun.real \
+    && printf '#!/bin/bash\nmpirun.real --allow-run-as-root "$@"\n' > /usr/local/bin/mpirun \
+    && chmod +x /usr/local/bin/mpirun \
+    && printf 'hwloc_base_binding_policy = none\nrmaps_base_mapping_policy = slot\n' \
+        >> /usr/local/etc/openmpi-mca-params.conf
+
+# Rebuild mpi4py against the new CUDA-aware OpenMPI
+RUN ${PIP} install --no-cache-dir --force-reinstall mpi4py
+
 # Configure CUDA-Q with MPI
 RUN bash "${CUDAQ_PATH}/distributed_interfaces/activate_custom_mpi.sh"
 

--- a/src/braket_container.py
+++ b/src/braket_container.py
@@ -335,6 +335,16 @@ def join_customer_script(customer_code_process: multiprocessing.Process):
     return customer_code_process.exitcode
 
 
+def _is_mpi_active() -> bool:
+    """Check if this process was launched under mpirun.
+
+    The OMPI_COMM_WORLD_SIZE environment variable is set by OpenMPI's mpirun
+    for all ranks. This avoids importing mpi4py (which would auto-initialize
+    MPI as a side effect).
+    """
+    return bool(os.getenv("OMPI_COMM_WORLD_SIZE"))
+
+
 def run_customer_code() -> None:
     """
     Downloads and runs the customer code. If the customer code exists
@@ -346,9 +356,19 @@ def run_customer_code() -> None:
     unpack_code_and_add_to_path(local_s3_file, compression_type)
     install_additional_requirements()
     customer_executable = extract_customer_code(entry_point)
-    customer_process = kick_off_customer_script(customer_executable)
-    if (exit_code := join_customer_script(customer_process)) != 0:
-        sys.exit(exit_code)
+
+    if _is_mpi_active():
+        # Run directly in the parent process to preserve MPI context.
+        # Forking after MPI_Init is discouraged by OpenMPI and causes
+        # finalization failures under mpirun.
+        print("MPI is active — running customer code in-process (no fork)")
+        kwargs = try_bind_hyperparameters_to_customer_method(customer_executable) or {}
+        wrap_customer_code(customer_executable, **kwargs)
+        print("Code Run Finished")
+    else:
+        customer_process = kick_off_customer_script(customer_executable)
+        if (exit_code := join_customer_script(customer_process)) != 0:
+            sys.exit(exit_code)
 
 
 def setup_and_run():

--- a/test/braket_tests/base/test_mpi.py
+++ b/test/braket_tests/base/test_mpi.py
@@ -24,6 +24,7 @@ from ..common.image_run_util import run_in_image
 from ..common.mpi_checks import (
     assert_mpi4py_init_no_crash,
     assert_mpi_runtime_launches_cleanly,
+    assert_mpirun_multirank_bcast,
 )
 
 
@@ -114,3 +115,11 @@ def test_mpi4py_init_no_crash_default_env(image_list):
     stronger check than the mpirun-only tests above.
     """
     assert_mpi4py_init_no_crash(image_list)
+
+
+def test_mpirun_multirank_bcast(image_list):
+    """Multi-rank MPI communication must work inside the container.
+    Verifies mpirun -np 2 with a basic bcast collective succeeds, catching
+    issues like fork-after-MPI_Init or broken shared-memory transport.
+    """
+    assert_mpirun_multirank_bcast(image_list)

--- a/test/braket_tests/common/mpi_checks.py
+++ b/test/braket_tests/common/mpi_checks.py
@@ -130,3 +130,38 @@ def assert_cudaq_mpi_initialize_finalize(image_list):
             f"(exit {result.returncode}).\n"
             f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
         )
+
+
+def assert_mpirun_multirank_bcast(image_list):
+    """Assert mpirun -np 2 can perform a basic MPI collective (bcast).
+
+    This is an integration test that verifies multi-rank MPI communication
+    works end-to-end inside the container. It catches issues such as forking
+    after MPI_Init (which corrupts shared-memory transport) and misconfigured
+    MCA parameters that prevent inter-process communication.
+    """
+    assert len(image_list) > 0, "Unable to find images for testing"
+    script = (
+        "from mpi4py import MPI; "
+        "comm = MPI.COMM_WORLD; "
+        "data = 42 if comm.Get_rank() == 0 else None; "
+        "data = comm.bcast(data, root=0); "
+        "assert data == 42; "
+        "print(f'rank {comm.Get_rank()} bcast OK')"
+    )
+    for image_path in image_list:
+        result = run_in_image(
+            image_path,
+            [
+                "bash", "-c",
+                f'mpirun -np 2 --oversubscribe --allow-run-as-root python -c "{script}"',
+            ],
+        )
+        assert result.returncode == 0, (
+            f"MPI bcast failed in {image_path} (exit {result.returncode}).\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "bcast OK" in result.stdout, (
+            f"Expected 'bcast OK' in output from {image_path}.\n"
+            f"stdout:\n{result.stdout}"
+        )

--- a/test/braket_tests/cudaq/test_mpi.py
+++ b/test/braket_tests/cudaq/test_mpi.py
@@ -22,7 +22,9 @@ from ..common.mpi_checks import (
     assert_cudaq_mpi_initialize_finalize,
     assert_cudaq_mpi_plugin_present,
     assert_mpi4py_init_no_crash,
+    assert_mpirun_multirank_bcast,
 )
+from ..common.image_run_util import run_in_image
 
 
 def test_mpi_init_no_crash_default_env(image_list):
@@ -50,3 +52,28 @@ def test_cudaq_mpi_initialize_finalize(image_list):
     in addition to basic MPI runtime sanity.
     """
     assert_cudaq_mpi_initialize_finalize(image_list)
+
+
+def test_cuda_aware_mpi_built(image_list):
+    """OpenMPI must be built with --with-cuda for cuStateVec mgpu support.
+    Without CUDA-aware MPI, cuStateVec segfaults when passing GPU device
+    pointers to MPI_Isend/MPI_Irecv during distributed state vector swaps.
+    """
+    assert len(image_list) > 0, "Unable to find images for testing"
+    for image_path in image_list:
+        result = run_in_image(
+            image_path,
+            [
+                "bash", "-c",
+                "ompi_info --parsable --all | grep mpi_built_with_cuda_support:value:true",
+            ],
+        )
+        assert result.returncode == 0, (
+            f"OpenMPI not built with CUDA support in {image_path}.\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+
+def test_mpirun_multirank_bcast(image_list):
+    """Multi-rank MPI communication must work in the CUDA-Q container."""
+    assert_mpirun_multirank_bcast(image_list)


### PR DESCRIPTION
Enables MPI support for Braket Hybrid Jobs, including multi-GPU/multi-node CUDA-Q `nvidia-mgpu` workloads.

*Issue #, if available:*

N/A

*Description of changes:*

**Change 1: Skip `multiprocessing.Process` fork when launched under mpirun**

When `sagemaker_mpi_enabled=true`, the SageMaker Training Toolkit launches `braket_container.py` via `mpirun ... python -m mpi4py braket_container.py`. Previously, `braket_container.py` would fork a child process via `multiprocessing.Process` to run customer code. This fork after `MPI_Init` causes job failures — OpenMPI [explicitly discourages](https://docs.open-mpi.org/en/main/tuning-apps/fork-system-popen.html) calling `fork()` in MPI processes.

Now, when `OMPI_COMM_WORLD_SIZE` is set (indicating launch under mpirun), customer code runs directly in-process. Non-MPI jobs continue to use the existing `multiprocessing.Process` path.

**Change 2: Rebuild OpenMPI with `--with-cuda` in the cudaq container**

cuStateVec's distributed index bit swap API passes GPU device pointers to `MPI_Isend()`/`MPI_Irecv()`. From [NVIDIA docs](https://docs.nvidia.com/cuda/cuquantum/latest/custatevec/overview/distributed-index-bit-swap.html):

> The MPI library should be CUDA-aware. The current release requires that `MPI_Isend()` and `MPI_Irecv()` accept device pointers.

The base image's OpenMPI is built without `--with-cuda` (confirmed via `ompi_info`: `mpi_built_with_cuda_support:value:false`). This causes segfaults when cuStateVec calls `MPI_Isend` with GPU pointers. The cudaq Dockerfile now rebuilds OpenMPI 4.1.8 with `--with-cuda`, using CUDA headers from the pip-installed nvidia packages. All other configure flags are preserved from the base image build.

*Testing done:*

- All 37 existing unit tests pass
- New bcast test verified locally: `docker run` with `mpirun -np 2 --oversubscribe` — both ranks communicate successfully
- Full end-to-end verified locally: `mpirun -np 2 python -m mpi4py braket_container.py` with patched image — no-fork path activates, customer code runs, bcast succeeds
- Validated on Braket Hybrid Jobs using distributed CUDA-Q state vector simulation (`nvidia-mgpu` target, 28-qubit GHZ circuit, 10M shots, BYOC containers built from this branch):
  - 1 GPU, no mpirun: uses fork path ("Running Code As Process"), 2716 MiB, 32.4s
  - 2 GPUs, 2 nodes (ml.g6.xlarge): uses no-fork path, 1758 MiB, 40.5s
  - 4 GPUs, 1 node (ml.g6.12xlarge): uses no-fork path, memory split across all 4 GPUs (1246+798+798+798 MiB), 36.3s
  - All expectation values consistent (~0, within 10M-shot statistical noise)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-containers/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
