### PR TITLE
fix: pin cudaq packages to cu12

### DIFF
--- a/cudaq/jobs/docker/0.14/py3/requirements.txt
+++ b/cudaq/jobs/docker/0.14/py3/requirements.txt
@@ -1,3 +1,3 @@
-cudaq==0.14.2
-cudaq-qec==0.6.0
-cudaq-solvers==0.6.0
+cuda-quantum-cu12==0.14.2
+cudaq-qec-cu12==0.6.0
+cudaq-solvers-cu12==0.6.0

--- a/pytorch/jobs/docker/2.8/py3/requirements.txt
+++ b/pytorch/jobs/docker/2.8/py3/requirements.txt
@@ -6,9 +6,9 @@ awscli==1.45.7
 botocore==1.43.7
 boto3==1.43.7
 certifi>=2026.4.22  # https://nvd.nist.gov/vuln/detail/CVE-2023-37920
-cudaq==0.14.2
-cudaq-qec==0.6.0
-cudaq-solvers==0.6.0
+cuda-quantum-cu12==0.14.2
+cudaq-qec-cu12==0.6.0
+cudaq-solvers-cu12==0.6.0
 dask==2024.8.0
 decorator==5.2.1
 h5py==3.16.0


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Avoid having multiple `cupy` versions by explicitly installing cu12 versions of each cudaq package.

Applying the same fix here that we're doing in https://github.com/amazon-braket/amazon-braket-examples/pull/903 to ensure CUDA version consistency across our containers.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-containers/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
