### PR TITLE
fix: harden pip against transient PyPI CDN 502s in specs and Dockerfiles

### DIFF
--- a/base/jobs/docker/1.0/py3/Dockerfile.cpu
+++ b/base/jobs/docker/1.0/py3/Dockerfile.cpu
@@ -41,7 +41,9 @@ FROM public.ecr.aws/lts/ubuntu:24.04 AS python-builder
 ENV DEBIAN_FRONTEND=noninteractive \
     PYTHON_VERSION=3.12.12 \
     PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    PIP_RETRIES=10 \
+    PIP_DEFAULT_TIMEOUT=60
 
 ARG PYTHON_PATH=/usr/local/bin/python3
 
@@ -96,7 +98,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
     LC_ALL=C.UTF-8 \
     LD_LIBRARY_PATH=/usr/local/openmpi/lib:/usr/local/lib:$LD_LIBRARY_PATH \
     PATH=/usr/local/bin:/usr/local/openmpi/bin/:$PATH \
-    SAGEMAKER_PROGRAM=braket_container.py
+    SAGEMAKER_PROGRAM=braket_container.py \
+    PIP_RETRIES=10 \
+    PIP_DEFAULT_TIMEOUT=60
 
 ARG HOME_DIR=/root
 ARG PYTHON_PATH=/usr/local/bin/python3

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,5 +1,10 @@
 version: 0.2
 
+env:
+  variables:
+    PIP_RETRIES: "10"
+    PIP_DEFAULT_TIMEOUT: "60"
+
 phases:
   install:
     runtime-versions:

--- a/cudaq/jobs/docker/0.14/py3/Dockerfile.cpu
+++ b/cudaq/jobs/docker/0.14/py3/Dockerfile.cpu
@@ -15,6 +15,9 @@ ENV OMPI_MCA_btl='^openib'
 ENV CXX=g++
 ENV LD_LIBRARY_PATH=${MPI_BASE_PATH}/lib:$LD_LIBRARY_PATH
 
+ENV PIP_RETRIES=10 \
+    PIP_DEFAULT_TIMEOUT=60
+
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
  && rm -rf /var/lib/apt/lists/* \

--- a/pytorch/jobs/docker/2.8/py3/Dockerfile.gpu
+++ b/pytorch/jobs/docker/2.8/py3/Dockerfile.gpu
@@ -29,6 +29,9 @@ ARG CUDAQ_PATH=/usr/local/lib/python${PYTHON_SHORT_VERSION}/site-packages
 ENV MPI_PATH=${MPI_BASE_PATH}
 ENV CXX=g++
 
+ENV PIP_RETRIES=10 \
+    PIP_DEFAULT_TIMEOUT=60
+
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     build-essential \

--- a/tensorflow/jobs/docker/2.19/py3/Dockerfile.gpu
+++ b/tensorflow/jobs/docker/2.19/py3/Dockerfile.gpu
@@ -8,6 +8,9 @@ LABEL major_version="1"
 ARG PIP=pip3
 ARG PYTHON=python3.12
 
+ENV PIP_RETRIES=10 \
+    PIP_DEFAULT_TIMEOUT=60
+
 # Patch OS packages: libtiff5/libtiffxx5 (CVE-2025-61144), libssl3/openssl
 # (CVE-2026-31789). ffmpeg + libav*/libsw* (CVE-2024-35366/35367/35368) have
 # no jammy community fix and are purged since hybrid jobs do not need them.

--- a/testspec.yml
+++ b/testspec.yml
@@ -1,4 +1,8 @@
 version: 0.2
+env:
+  variables:
+    PIP_RETRIES: "10"
+    PIP_DEFAULT_TIMEOUT: "60"
 phases:
   install:
     runtime-versions:
@@ -21,9 +25,11 @@ phases:
       - echo Testing images at $CODEBUILD_SRC_DIR_BUILD_RESULTS...
       - pytest test/unit_tests
       - |
+        set -eo pipefail
         echo Running Braket tests...
         pytest test/braket_tests/$FRAMEWORK -vv --from-build-results $CODEBUILD_SRC_DIR_BUILD_RESULTS/build_results.txt
       - |
+        set -eo pipefail
         echo Running SageMaker tests...
         pip install -r test/requirements-sagemaker.txt
         pytest test/sagemaker_tests -vv --from-build-results $CODEBUILD_SRC_DIR_BUILD_RESULTS/build_results.txt


### PR DESCRIPTION
## Problem

The base / tensorflow / pytorch container build pipelines failed on 2026-08-17 and 2026-08-18 due to transient HTTP 502s from `files.pythonhosted.org` (PyPI's Fastly CDN) during pip wheel-metadata fetches. The same source revision built successfully before and after, confirming an upstream transient rather than a code or dependency defect.

One failure surfaced misleadingly as `ModuleNotFoundError: No module named 'sagemaker'`: the SageMaker test block ran `pytest` even after its `pip install` had already failed, because the block had no `set -e`.

## Fix

Failures occurred at two layers, so both are hardened.

**CodeBuild host** (`buildspec.yml`, `testspec.yml`)
- Set `PIP_RETRIES=10` and `PIP_DEFAULT_TIMEOUT=60` as build env vars so every host-level pip install survives transient 502s.
- Add `set -eo pipefail` to the Braket and SageMaker test blocks so a failed pip install aborts the block instead of silently falling through to `pytest`.

**Image build** (`base`, `cudaq`, `pytorch`, `tensorflow` Dockerfiles)
- Set `ENV PIP_RETRIES=10` / `PIP_DEFAULT_TIMEOUT=60` so in-image pip installs — which do not inherit CodeBuild env vars — are also resilient. `base` is multi-stage, so the ENV is set in both the `python-builder` and final stages.

No dependency or version pins are changed. YAML specs validated.

## Testing

- `buildspec.yml` / `testspec.yml` validated as well-formed YAML.
- Change is limited to pip retry/timeout budgets and shell error propagation; image contents are unchanged.
- Recommended: re-run the affected pipelines to confirm green builds.