### PR TITLE
fix: use POSIX-safe `set -e` in testspec, not `set -eo pipefail`

### DIFF
--- a/testspec.yml
+++ b/testspec.yml
@@ -25,11 +25,11 @@ phases:
       - echo Testing images at $CODEBUILD_SRC_DIR_BUILD_RESULTS...
       - pytest test/unit_tests
       - |
-        set -eo pipefail
+        set -e
         echo Running Braket tests...
         pytest test/braket_tests/$FRAMEWORK -vv --from-build-results $CODEBUILD_SRC_DIR_BUILD_RESULTS/build_results.txt
       - |
-        set -eo pipefail
+        set -e
         echo Running SageMaker tests...
         pip install -r test/requirements-sagemaker.txt
         pytest test/sagemaker_tests -vv --from-build-results $CODEBUILD_SRC_DIR_BUILD_RESULTS/build_results.txt


### PR DESCRIPTION
## Problem

[#510](https://github.com/amazon-braket/amazon-braket-containers/pull/510) added `set -eo pipefail` to the **Braket tests** and **SageMaker tests** command blocks in `testspec.yml` to make a failed `pip install` abort the block instead of falling through to `pytest`.

CodeBuild executes each buildspec/testspec command block under **`/bin/sh` (dash)**, whose `set` builtin does not support `-o pipefail`. The block therefore aborts on its very first line:

```
/codebuild/output/tmp/script.sh: 4: set: Illegal option -o pipefail
... exit status 2
```

`pytest` never runs. The alarm/summary surfaced this misleadingly as a test failure, but the shell aborts first — `pytest test/unit_tests` (the preceding line, with no `pipefail` prefix) still passes (36 passed, 1 xpassed).

**Impact:** all four container build pipelines (`base`, `cudaq`, `pytorch`, `tensorflow`) failed deterministically in the Test stage on the first scheduled build after #510 merged (2026-08-19 18:00 UTC), and would fail every scheduled run until fixed. The Build/Source stages are unaffected — images build fine.

## Fix

Replace `set -eo pipefail` with `set -e` in both blocks. Neither block contains a pipeline, so `pipefail` added no behavior; `set -e` is dash-safe and still aborts the block on a failed `pip install` — the exact behavior #510 was after (the SageMaker block's `pip install` -> `pytest` fall-through).

## Testing

- `testspec.yml` validated as well-formed YAML.
- Two-line change; no dependency, image, or test-content changes.
- Recommended: re-run the four affected pipelines to confirm green Test stages.

## Refs

- Regressed by #510
- Alarms: P494890050 (cudaq, us-west-2), V2332640481 (tensorflow, us-east-1); `base` and `pytorch` failed identically without separate tickets.